### PR TITLE
Issue/25/path links putting chrome ext path

### DIFF
--- a/.github/workflows/cron-test.yml
+++ b/.github/workflows/cron-test.yml
@@ -1,0 +1,35 @@
+name: Continuous Integration Chron
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 12 * * *"
+
+jobs:
+  build:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: Run install
+        run: yarn install
+
+      - name: Install Cypress dependencies
+        working-directory: tests/cypress
+        run: yarn install
+
+      - name: Run build
+        run: yarn build
+
+      - name: Test the app
+        run: yarn test
+
+      - name: Run Cypress
+        working-directory: tests/cypress
+        run: yarn cypress:run

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,7 +9,7 @@
     "host_permissions": [
         "https://github.com/*"
     ],
-    "version":"0.0.0.7",
+    "version":"0.0.0.8",
     "action":{
         "default_popup": "index.html"
     },

--- a/src/models/DisplayHclModule.ts
+++ b/src/models/DisplayHclModule.ts
@@ -1,12 +1,6 @@
 import {IDisplayHlcModule} from "./IDisplayHclModule";
 import {SourceTypes} from "../types/SourceTypes";
 import {Nullable} from "../types/Nullable";
-import {
-    FileExtensions,
-    GITHUB_ROUTES,
-    TERRAFORM_REGISTRY_ROUTES,
-    TERRAFORM_SYNTAX
-} from "../util/constants";
 import { TerraformModule } from "../types/Terraform";
 import {HclSourceService} from "../services/HclSourceService";
 
@@ -26,7 +20,7 @@ export class DisplayHlcModule implements IDisplayHlcModule {
         if (terraformModule.provider.source !== undefined && terraformModule.provider.source !== '' && terraformModule.provider.version !== undefined) {
             this.source = terraformModule.provider.source
             this.sourceType = this.hclSourceService.GetSourceType(terraformModule.provider.source)
-            this.modifiedSourceType = this.hclSourceService.ResolveSource(this.sourceType, terraformModule.provider.source, terraformModule.moduleName, terraformModule.provider.version)
+            this.modifiedSourceType = this.hclSourceService.ResolveSource(this.sourceType, terraformModule.provider.source, terraformModule.moduleName, terraformModule.provider.version, new URL(uri))
         }
 
     }

--- a/src/popup-page/popup.tsx
+++ b/src/popup-page/popup.tsx
@@ -3,18 +3,19 @@ import {render} from 'react-dom'
 import {
     Container,
     CssBaseline,
-    Typography,
+    Link,
     Table,
     TableBody,
+    TableCell,
     TableContainer,
     TableFooter,
-    TableRow, TablePagination, TableCell, Link
+    TablePagination,
+    TableRow,
+    Typography
 } from '@mui/material';
 import {DisplayHlcModule} from "../models/DisplayHclModule";
 import {SourceTypes} from "../types/SourceTypes";
-import {
-    TablePaginationActions
-} from "../components/TablePaginationComponent";
+import {TablePaginationActions} from "../components/TablePaginationComponent";
 
 interface IProps {}
 

--- a/src/services/HclService.ts
+++ b/src/services/HclService.ts
@@ -17,8 +17,8 @@ export class HclService {
         );
     }
 
-    getFileType = (isSignedIn: boolean):Nullable<HclFileTypes> => {
-        const finalPath = isSignedIn ? document.getElementById("file-name-id") : document.querySelector('.final-path') as HTMLElement
+    getFileType = ():Nullable<HclFileTypes> => {
+        const finalPath =  document.getElementById("file-name-id") as HTMLElement
         const innerText = finalPath?.innerText ?? '';
         const fileType = innerText.split('.');
         if(fileType.length !== 2){
@@ -103,17 +103,11 @@ export class HclService {
     }
 
 
-    findSources = (isSignedIn: boolean):DisplayHlcModule[] => {
+    findSources = ():DisplayHlcModule[] => {
 
-        let dataTargetElement = null;
-        let innerText = '';
-        if(isSignedIn){
-            dataTargetElement = document.getElementById('read-only-cursor-text-area') as HTMLTextAreaElement;
-            innerText = dataTargetElement.value;
-        } else {
-            dataTargetElement = document.querySelector('table') as HTMLElement;
-            innerText = dataTargetElement.innerText;
-        }
+        let dataTargetElement = document.getElementById('read-only-cursor-text-area') as HTMLTextAreaElement;
+        let innerText = dataTargetElement.value;
+
         if(innerText === ''){
             return [];
         }

--- a/src/services/HclSourceService.ts
+++ b/src/services/HclSourceService.ts
@@ -41,7 +41,7 @@ export class HclSourceService {
             case SourceTypes.ssh:
                 return this.sshToUrl(source);
             case SourceTypes.path:
-                return this.pathToUrl(source,url.origin ,url.pathname);
+                return this.pathToUrl(source,url.href);
             case SourceTypes.registry:
                 return this.registryToUrl(source, moduleName, sourceVersion);
             case SourceTypes.privateRegistry:
@@ -99,18 +99,11 @@ export class HclSourceService {
         return `https://registry.terraform.io/${providerType}/${sourcePath}/${version}`
     }
 
-    pathToUrl = (source: string, origin: string ,currentPath: string): string => {
+    pathToUrl = (source: string, sourcePageUrl: string): string => {
         if(!this.IsFilePath(source)){
             throw new Error(`${source} is not of type ${SourceTypes.path.toString()}`);
         }
-        let directoriesUpCount = 1;
-        [...source.split("./"),...source.split("../")].forEach(dp => {
-            if(dp === ""){
-                directoriesUpCount += 1
-            }
-        });
-        let splitCurrentPath = currentPath.split("/").filter(Boolean).slice(0,-1 * directoriesUpCount);
-        return `${origin}/${splitCurrentPath.join("/")}/${source.replaceAll("../","").replaceAll("./","")}`
+        return new URL(source,sourcePageUrl).href
     }
 
     IsHost = (source: string): boolean =>  {

--- a/src/services/HclSourceService.ts
+++ b/src/services/HclSourceService.ts
@@ -30,7 +30,7 @@ export class HclSourceService {
         return null;
     }
 
-    ResolveSource = (sourceType: Nullable<SourceTypes>, source: string, moduleName: string, sourceVersion: string): Nullable<string> => {
+    ResolveSource = (sourceType: Nullable<SourceTypes>, source: string, moduleName: string, sourceVersion: string, url: URL): Nullable<string> => {
         if(sourceType === null){
             return null;
         }
@@ -41,7 +41,7 @@ export class HclSourceService {
             case SourceTypes.ssh:
                 return this.sshToUrl(source);
             case SourceTypes.path:
-                return source;
+                return this.pathToUrl(source,url.origin ,url.pathname);
             case SourceTypes.registry:
                 return this.registryToUrl(source, moduleName, sourceVersion);
             case SourceTypes.privateRegistry:
@@ -97,6 +97,20 @@ export class HclSourceService {
         }
 
         return `https://registry.terraform.io/${providerType}/${sourcePath}/${version}`
+    }
+
+    pathToUrl = (source: string, origin: string ,currentPath: string): string => {
+        if(!this.IsFilePath(source)){
+            throw new Error(`${source} is not of type ${SourceTypes.path.toString()}`);
+        }
+        let directoriesUpCount = 1;
+        [...source.split("./"),...source.split("../")].forEach(dp => {
+            if(dp === ""){
+                directoriesUpCount += 1
+            }
+        });
+        let splitCurrentPath = currentPath.split("/").filter(Boolean).slice(0,-1 * directoriesUpCount);
+        return `${origin}/${splitCurrentPath.join("/")}/${source.replaceAll("../","").replaceAll("./","")}`
     }
 
     IsHost = (source: string): boolean =>  {

--- a/src/services/InMemoryCache.ts
+++ b/src/services/InMemoryCache.ts
@@ -1,0 +1,19 @@
+import {Nullable} from "../types/Nullable";
+
+export class InMemoryCache {
+    private _cache = new Map<string,any>()
+
+    Set<T>(key: string, value: T){
+        if(this._cache.has(key)){
+            this._cache.delete(key)
+            this._cache.set(key,value)
+        }
+        this._cache.set(key,value)
+    }
+    Get<T>(key: string) : Nullable<T> {
+        if(this._cache.has(key)){
+            return this._cache.get(key) as T
+        }
+        return null;
+    }
+}

--- a/src/services/InMemoryCache.ts
+++ b/src/services/InMemoryCache.ts
@@ -1,18 +1,19 @@
 import {Nullable} from "../types/Nullable";
 
 export class InMemoryCache {
-    private _cache = new Map<string,any>()
+    //private static readonly _cache: Map<string,any> = new Map<string, any>()
+    private static readonly _cache: Map<string,any> = new Map<string, any>();
 
     Set<T>(key: string, value: T){
-        if(this._cache.has(key)){
-            this._cache.delete(key)
-            this._cache.set(key,value)
+        if(InMemoryCache._cache.has(key)){
+            InMemoryCache._cache.delete(key)
+            InMemoryCache._cache.set(key,value)
         }
-        this._cache.set(key,value)
+        InMemoryCache._cache.set(key,value)
     }
     Get<T>(key: string) : Nullable<T> {
-        if(this._cache.has(key)){
-            return this._cache.get(key) as T
+        if(InMemoryCache._cache.has(key)){
+            return InMemoryCache._cache.get(key) as T
         }
         return null;
     }

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -45,3 +45,7 @@ export const GITHUB_LINKS = {
     SIGN_IN: 'Sign in',
     SIGN_UP: 'Sign up'
 }
+
+export const CacheKeys = {
+    MODULES: 'MODULES'
+}

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -47,5 +47,6 @@ export const GITHUB_LINKS = {
 }
 
 export const CacheKeys = {
-    MODULES: 'MODULES'
+    MODULES: "MODULES",
+    CURRENT_TAB_URL: "CurrentTabUrl"
 }

--- a/tests/cypress/cypress/e2e/github.cy.ts
+++ b/tests/cypress/cypress/e2e/github.cy.ts
@@ -7,7 +7,7 @@ it('should be able to navigate to github.com', () => {
 
 it('should be able to find the file extension on github.com', () => {
   cy.visit('https://github.com/NickSpaghetti/Salve-Amulet-Checker/blob/master/src/main/java/com/sac/SalveAmuletCheckerPlugin.java');
-  cy.get('[class="final-path"]')
+  cy.get('[id="file-name-id"]')
       .should('have.length',1)
       .then((currentSubject) => {
         cy.wrap(currentSubject[0].innerText).should('equal','SalveAmuletCheckerPlugin.java');
@@ -15,20 +15,24 @@ it('should be able to find the file extension on github.com', () => {
 });
 
 
-it('should be able to find the java code on github.com', () => {
+it('find java code', () => {
     cy.visit('https://github.com/NickSpaghetti/Salve-Amulet-Checker/blob/master/src/main/java/com/sac/SalveAmuletCheckerPlugin.java');
-    cy.get('table')
-        .should('have.length',1)
-        .then((currentSubject) => {
-            cy.wrap(currentSubject[0].innerText).should('not.be.empty');
-        });
+    cy.get("#read-only-cursor-text-area")
+        .should('not.be.undefined')
+
 });
 
-it('should be signed out', () => {
+it('find data-code-text', () => {
+    cy.visit('https://github.com/NickSpaghetti/terraform-up-and-running-3rd-edition/blob/main/Chapters/6/main.tf');
+    cy.get('span[data-code-test*="hashicorp/aws"]')
+        .should('not.be.undefined')
+
+});
+
+it('should find the code', () => {
     cy.visit('https://github.com/NickSpaghetti/Salve-Amulet-Checker/blob/master/src/main/java/com/sac/SalveAmuletCheckerPlugin.java');
     cy.contains('a','Sign up')
         .should('be.visible')
-
-});
+})
 
 

--- a/tests/unit/services/HclSourceServices.test.ts
+++ b/tests/unit/services/HclSourceServices.test.ts
@@ -228,13 +228,13 @@ describe("Given a ssh host", () => {
 describe("Given a relative file path", () => {
     describe("When relative path is host is ../../base/ec2-baseline and the path is https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/mgmt/lambdas/main.tf", () => {
         test("Then I expect the url to be  https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/base/ec2-baseline", () => {
-            expect<string>(hlcSourceService.pathToUrl("../../base/ec2-baseline", "https://github.com","/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/mgmt/lambdas/main.tf"))
+            expect<string>(hlcSourceService.pathToUrl("../../base/ec2-baseline", "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/mgmt/lambdas/main.tf"))
                 .toBe("https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/base/ec2-baseline");
         });
     });
     describe("When relative path is host is ../base/ec2-baseline and the path is https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/mgmt/lambdas/main.tf", () => {
         test("Then I expect the url to be  https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/base/ec2-baseline", () => {
-            expect<string>(hlcSourceService.pathToUrl("../base/ec2-baseline", "https://github.com","/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/mgmt/lambdas/main.tf"))
+            expect<string>(hlcSourceService.pathToUrl("../base/ec2-baseline", "https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/mgmt/lambdas/main.tf"))
                 .toBe("https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/mgmt/base/ec2-baseline");
         });
     });
@@ -297,7 +297,7 @@ describe("Given a SourceType, Source,  ModuleName, and Source Version", () => {
     describe("When path, ../foo/bar, foo, ''", () => {
         test("I expect the result to be ../foo/bar", ()=>{
             expect(hlcSourceService.ResolveSource(SourceTypes.path, "../foo/bar",'foo','',new URL("https://github.com/NickSpaghetti/terraform-up-and-running-3rd-edition/blob/main/Chapters/5/modules/services/webserver-cluster/main.tf")))
-                .toBe("https://github.com/NickSpaghetti/terraform-up-and-running-3rd-edition/blob/main/Chapters/5/modules/services/webserver-cluster/foo/bar");
+                .toBe("https://github.com/NickSpaghetti/terraform-up-and-running-3rd-edition/blob/main/Chapters/5/modules/services/foo/bar");
         });
     });
 

--- a/tests/unit/services/HclSourceServices.test.ts
+++ b/tests/unit/services/HclSourceServices.test.ts
@@ -210,6 +210,7 @@ describe("Given a ssh host", () => {
         });
     });
 
+
     describe("When ssh host is invalid", () => {
         test("Then I expect the url to be the original ssh host", () => {
             expect<string>(hlcSourceService.sshToUrl(""))
@@ -223,6 +224,21 @@ describe("Given a ssh host", () => {
         });
     });
 });
+
+describe("Given a relative file path", () => {
+    describe("When relative path is host is ../../base/ec2-baseline and the path is https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/mgmt/lambdas/main.tf", () => {
+        test("Then I expect the url to be  https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/base/ec2-baseline", () => {
+            expect<string>(hlcSourceService.pathToUrl("../../base/ec2-baseline", "https://github.com","/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/mgmt/lambdas/main.tf"))
+                .toBe("https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/base/ec2-baseline");
+        });
+    });
+    describe("When relative path is host is ../base/ec2-baseline and the path is https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/mgmt/lambdas/main.tf", () => {
+        test("Then I expect the url to be  https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/base/ec2-baseline", () => {
+            expect<string>(hlcSourceService.pathToUrl("../base/ec2-baseline", "https://github.com","/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/mgmt/lambdas/main.tf"))
+                .toBe("https://github.com/gruntwork-io/terraform-aws-lambda/tree/v0.21.6/modules/mgmt/base/ec2-baseline");
+        });
+    });
+})
 
 describe("Given a Source", () => {
     describe("When the Source is an Empty String", () => {
@@ -266,53 +282,54 @@ describe("Given a Source", () => {
 describe("Given a SourceType, Source,  ModuleName, and Source Version", () => {
     describe("When url, github.com, foo, ''", () => {
         test("I expect the result to be github.com", ()=>{
-            expect(hlcSourceService.ResolveSource(SourceTypes.url, "github.com",'foo',''))
+            expect(hlcSourceService.ResolveSource(SourceTypes.url, "github.com",'foo','',new URL("https://github.com")))
                 .toBe("github.com");
         });
     });
 
     describe("When ssh, git::git@github.com:gruntwork-io/terraform-aws-lambda.git//modules/lambda.tf?ref=v2.0.0, foo, ''", () => {
         test("I expect the result to be https://github.com/gruntwork-io/terraform-aws-lambda/tree/v2.0.0/modules/lambda", ()=>{
-            expect(hlcSourceService.ResolveSource(SourceTypes.ssh, "git::git@github.com:gruntwork-io/terraform-aws-lambda.git//modules/lambda?ref=v2.0.0",'foo',''))
+            expect(hlcSourceService.ResolveSource(SourceTypes.ssh, "git::git@github.com:gruntwork-io/terraform-aws-lambda.git//modules/lambda?ref=v2.0.0",'foo','',new URL("https://github.com")))
                 .toBe("https://github.com/gruntwork-io/terraform-aws-lambda/tree/v2.0.0/modules/lambda");
         });
     });
 
     describe("When path, ../foo/bar, foo, ''", () => {
         test("I expect the result to be ../foo/bar", ()=>{
-            expect(hlcSourceService.ResolveSource(SourceTypes.path, "../foo/bar",'foo',''))
-                .toBe("../foo/bar");
+            expect(hlcSourceService.ResolveSource(SourceTypes.path, "../foo/bar",'foo','',new URL("https://github.com/NickSpaghetti/terraform-up-and-running-3rd-edition/blob/main/Chapters/5/modules/services/webserver-cluster/main.tf")))
+                .toBe("https://github.com/NickSpaghetti/terraform-up-and-running-3rd-edition/blob/main/Chapters/5/modules/services/webserver-cluster/foo/bar");
         });
     });
 
     describe("When path, ./foo/bar, foo, ''", () => {
         test("I expect the result to be github.com", ()=>{
-            expect(hlcSourceService.ResolveSource(SourceTypes.path, "./foo/bar",'foo',''))
-                .toBe("./foo/bar");
+            expect(hlcSourceService.ResolveSource(SourceTypes.path, "./foo/bar",'foo','',new URL("https://github.com/NickSpaghetti/terraform-up-and-running-3rd-edition/blob/main/Chapters/5/modules/services/webserver-cluster/main.tf")))
+                .toBe("https://github.com/NickSpaghetti/terraform-up-and-running-3rd-edition/blob/main/Chapters/5/modules/services/webserver-cluster/foo/bar");
         });
     });
 
     describe("When registry, hashicorp/aws foo, ''", () => {
         test("I expect the result to be https://registry.terraform.io/modules/hashicorp/aws/", ()=>{
-            expect(hlcSourceService.ResolveSource(SourceTypes.registry, "hashicorp/aws",'foo',''))
+            expect(hlcSourceService.ResolveSource(SourceTypes.registry, "hashicorp/aws",'foo','',new URL("https://github.com")))
                 .toBe("https://registry.terraform.io/modules/hashicorp/aws/");
         });
     });
 
     describe("When registry, hashicorp/aws foo, '1.0.0'", () => {
         test("I expect the result to be github.com", ()=>{
-            expect(hlcSourceService.ResolveSource(SourceTypes.registry, "hashicorp/aws",'foo','1.0.0'))
+            expect(hlcSourceService.ResolveSource(SourceTypes.registry, "hashicorp/aws",'foo','1.0.0',new URL("https://github.com")))
                 .toBe("https://registry.terraform.io/modules/hashicorp/aws/1.0.0");
         });
     });
 
     describe("When private registry, bar.terraform.io/foo/aws foo, ''", () => {
         test("I expect the result to be bar.terraform.io/foo/aws", ()=>{
-            expect(hlcSourceService.ResolveSource(SourceTypes.privateRegistry, "bar.terraform.io/foo/aws",'foo','1.0.0'))
+            expect(hlcSourceService.ResolveSource(SourceTypes.privateRegistry, "bar.terraform.io/foo/aws",'foo','1.0.0',new URL("https://github.com")))
                 .toBe("bar.terraform.io/foo/aws");
         });
     });
 })
+
 
 
 


### PR DESCRIPTION
Added InMemoryCache.ts to keep modules cached to help with performance. Updated DisplayHclModule.ts to pass in the uri to figure out where we are in the file tree since in popup.tsx reference fileTypes break. Removed isSignedIntoGithub Checks since the html now looks the same whether you are signed in.